### PR TITLE
This commit resolves two critical bugs related to rendering HTML repo…

### DIFF
--- a/modules/UIFunctions.psm1
+++ b/modules/UIFunctions.psm1
@@ -430,12 +430,12 @@ function RenderSessionHistory() {
         $null = $sessionData.Add($sessionObject)
     }
 
-    $jsonData = $sessionData | ConvertTo-Json -Depth 5
+    $jsonData = @($sessionData) | ConvertTo-Json -Depth 5
     if ([string]::IsNullOrEmpty($jsonData)) {
         $jsonData = "[]"
     }
 
-    $report = (Get-Content $workingDirectory\ui\templates\SessionHistory.html.template) -replace '"_SESSIONDATA_"', $jsonData
+    $report = (Get-Content $workingDirectory\ui\templates\SessionHistory.html.template) -replace '_SESSIONDATA_', $jsonData
     $report | Out-File -encoding UTF8 $workingDirectory\ui\SessionHistory.html
 }
 


### PR DESCRIPTION
…rts and improves the robustness of the UI functions.

1.  **Fix 'Most Played' chart rendering:** The chart failed to render when game data was present due to an unnecessary `HtmlDecode` call corrupting the injected JSON data. This call has been removed. The logic was also improved to display games with zero playtime instead of showing a blank page.

2.  **Fix 'Session History' page:** A regression was introduced that broke the Session History page. This was caused by an incorrect placeholder name in the `RenderSessionHistory` function's `-replace` command. This has been corrected.

3.  **Systemic Improvement:** The root cause of the initial bug, the `HtmlDecode` call, was present in all page-rendering functions. It has been removed from all of them (`RenderGameList`, `RenderGamingTime`, `RenderSummary`, `RenderIdleTime`, `RenderGamesPerPlatform`, `RenderSessionHistory`) to prevent similar hard-to-diagnose UI bugs in the future.

All relevant JSON conversions have also been wrapped in `@()` to ensure they always produce arrays, preventing errors when a query returns a single result.