### PR TITLE
feat: Add end time and fix styling on Session History page

### DIFF
--- a/modules/UIFunctions.psm1
+++ b/modules/UIFunctions.psm1
@@ -418,6 +418,7 @@ function RenderSessionHistory() {
         $sessionDateTime = $origin.AddSeconds($sessionRecord.session_start_time).ToLocalTime()
         $startDateFormatted = $sessionDateTime.ToString("yyyy-MM-dd")
         $startTimeFormatted = $sessionDateTime.ToString("HH:mm:ss")
+        $endTimeFormatted = $sessionDateTime.AddMinutes($durationMinutes).ToString("HH:mm:ss")
         # --- End Data Formatting ---
 
         $sessionObject = [pscustomobject]@{
@@ -426,6 +427,7 @@ function RenderSessionHistory() {
             Duration  = $durationFormatted
             StartDate = $startDateFormatted
             StartTime = $startTimeFormatted
+            EndTime   = $endTimeFormatted
         }
         $null = $sessionData.Add($sessionObject)
     }

--- a/ui/resources/css/SessionHistory.css
+++ b/ui/resources/css/SessionHistory.css
@@ -19,10 +19,6 @@ th {
   text-align: center !important;
 }
 
-th:first-child {
-  color: #333;
-}
-
 /* Table Row styles */
 tr:hover {
   background-color: gray !important;
@@ -39,40 +35,48 @@ tr:nth-child(even) {
 /* Table Cell & Column styles */
 td {
   border: 1px solid #333;
-  width: auto;
   text-align: center;
   height: 50px;
   padding: 6px 5px !important;
 }
 
-/* Define specific styles for the Icon column */
-td:first-child {
-  width: 5%;
+.game-cell {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding-left: 10px;
 }
 
-td:first-child img {
-  height: 70px;
-  margin-left: auto;
-  margin-right: auto;
-  display: block;
-  filter: drop-shadow(4px 4px 2px gray);
+.game-icon {
+  height: 40px;
+  margin-right: 10px;
+  filter: drop-shadow(3px 3px 1px gray);
 }
 
-/* Define specific styles for the Name column */
-td:nth-child(2) {
+.game-cell span {
   font-weight: bold;
-  width: 45%;
   text-transform: uppercase;
 }
 
-/* Define specific styles for the Duration column */
-td:nth-child(3) {
+#sessionHistoryTable td:nth-child(1) {
+  width: 20%;
+  text-align: left;
+}
+
+#sessionHistoryTable td:nth-child(2) {
   width: 20%;
 }
 
-/* Define specific styles for the Start Time column */
-td:nth-child(4) {
-    width: 30%;
+#sessionHistoryTable td:nth-child(3) {
+  width: 20%;
+}
+
+#sessionHistoryTable td:nth-child(4) {
+  width: 20%;
+}
+
+#sessionHistoryTable td:nth-child(5) {
+  width: 20%;
 }
 
 

--- a/ui/resources/js/SessionHistory.js
+++ b/ui/resources/js/SessionHistory.js
@@ -17,6 +17,7 @@ $(document).ready(function() {
         const safeDuration = DOMPurify.sanitize(session.Duration);
         const safeStartDate = DOMPurify.sanitize(session.StartDate);
         const safeStartTime = DOMPurify.sanitize(session.StartTime);
+        const safeEndTime = DOMPurify.sanitize(session.EndTime);
 
         // Create the HTML for the new table row
         const row = `
@@ -30,6 +31,7 @@ $(document).ready(function() {
                 <td>${safeDuration}</td>
                 <td>${safeStartDate}</td>
                 <td>${safeStartTime}</td>
+                <td>${safeEndTime}</td>
             </tr>
         `;
         // Append the new row to the table body
@@ -47,7 +49,8 @@ $(document).ready(function() {
             { "targets": 0, "orderable": true, "searchable": true }, // Game
             { "targets": 1, "orderable": false, "searchable": false }, // Duration
             { "targets": 2, "orderable": true, "searchable": true }, // Date
-            { "targets": 3, "orderable": true, "searchable": false }  // Time
+            { "targets": 3, "orderable": true, "searchable": false },  // Start Time
+            { "targets": 4, "orderable": true, "searchable": false }  // End Time
         ]
     });
 });

--- a/ui/templates/SessionHistory.html.template
+++ b/ui/templates/SessionHistory.html.template
@@ -22,6 +22,7 @@
             <th>Duration</th>
             <th>Date</th>
             <th>Start Time</th>
+            <th>End Time</th>
           </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
This commit introduces several enhancements to the Session History page.

- Adds an 'End Time' column to the table to show when a session concluded.
- Updates the PowerShell backend to calculate and provide the end time data.
- Adjusts the CSS to provide a responsive 5-column layout with equal-width columns.
- Fixes an issue where the 'Game' column header text was not visible against the background.