### PR TITLE
Fix(ui): Prevent duplicate integer ticks on x-axis

### DIFF
--- a/ui/resources/js/MostPlayed.js
+++ b/ui/resources/js/MostPlayed.js
@@ -60,6 +60,8 @@ function updateMostPlayedChart(gameCount) {
           type: "linear",
           title: chartTitleConfig("Playtime (Hours)", 15),
           ticks: {
+            stepSize: 60,
+            precision: 0,
             callback: function(value) {
                 // Display ticks as hours
                 return Math.floor(value / 60);


### PR DESCRIPTION
The x-axis on the 'Most Played' chart was displaying duplicate integer hour values. This was because the tick generation was not aligned with hour intervals.

This change configures the x-axis to have a step size of 60 minutes and a precision of 0, ensuring that ticks are only created at whole hour intervals.