### PR TITLE
Fix: Display idle time in hours instead of minutes

### DIFF
--- a/modules/UIFunctions.psm1
+++ b/modules/UIFunctions.psm1
@@ -335,7 +335,7 @@ function RenderIdleTime() {
 
     $workingDirectory = (Get-Location).Path
 
-    $getGamesIdleTimeDataQuery = "SELECT name, idle_time as time FROM games WHERE idle_time > 0 ORDER BY idle_time DESC"
+    $getGamesIdleTimeDataQuery = "SELECT name, ROUND(idle_time / 60.0, 2) as time FROM games WHERE idle_time > 0 ORDER BY idle_time DESC"
     $gamesIdleTimeData = RunDBQuery $getGamesIdleTimeDataQuery
     if ($gamesIdleTimeData.Length -eq 0) {
         if(-Not $InBackground) {

--- a/ui/resources/js/GameVsTime.js
+++ b/ui/resources/js/GameVsTime.js
@@ -53,21 +53,29 @@ function updateChart(gameCount, labelText) {
           },
         },
         x: {
-          type: "linear", // Use a standard linear axis
+          type: "linear",
           title: chartTitleConfig(labelText, 15),
+          ticks: {
+            stepSize: 1,
+            callback: function (value) {
+              if (Math.floor(value) === value) {
+                return value + "h";
+              }
+            },
+          },
         },
       },
       plugins: {
         tooltip: {
           enabled: true,
           callbacks: {
-            label: function(context) {
+            label: function (context) {
               const value = context.raw;
-              const hours = Math.floor(value / 60);
-              const minutes = value % 60;
+              const hours = Math.floor(value);
+              const minutes = Math.round((value - hours) * 60);
               return `${hours}h ${minutes}m`;
-            }
-          }
+            },
+          },
         },
         legend: {
           display: false,
@@ -79,8 +87,8 @@ function updateChart(gameCount, labelText) {
             if (value === 0) {
               return "";
             }
-            const hours = Math.floor(value / 60);
-            const minutes = value % 60;
+            const hours = Math.floor(value);
+            const minutes = Math.round((value - hours) * 60);
             return `${hours}h ${minutes}m`;
           },
           color: "#000000",
@@ -88,7 +96,7 @@ function updateChart(gameCount, labelText) {
             family: "monospace",
           },
         },
-      }
+      },
     },
   });
 }


### PR DESCRIPTION
The Idle Time page was displaying time in minutes while the axis label indicated hours. This commit standardizes the page to display time in hours, consistent with other pages in the application.

- Modified the `RenderIdleTime` function in `modules/UIFunctions.psm1` to convert idle time from minutes to hours before rendering the page.
- Updated `ui/resources/js/GameVsTime.js` to correctly format the hour-based values in tooltips and data labels.
- Configured the x-axis to display ticks only for integer hours, with an 'h' suffix, as requested by the user.